### PR TITLE
Add postman collection+environement to help simulate a maker creating orders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -56,3 +56,6 @@ package.json
 
 # comit-sdk
 app/comit-sdk/*
+
+# postman
+postman/*

--- a/postman/CND Orderbook REST API.postman_collection.json
+++ b/postman/CND Orderbook REST API.postman_collection.json
@@ -1,0 +1,259 @@
+{
+	"info": {
+		"_postman_id": "7f4ce528-698e-476e-9942-d9c002416ab6",
+		"name": "CND Orderbook REST API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "ARCHIVED",
+			"item": [
+				{
+					"name": "GET / (Taker)",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{TAKER_CND_URL}}",
+							"host": [
+								"{{TAKER_CND_URL}}"
+							]
+						},
+						"description": "GET /\n"
+					},
+					"response": []
+				},
+				{
+					"name": "POST /dial (Maker2Taker)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"addresses\": [\"/ip4/124.19.31.4/tcp/9939\"]\n}"
+						},
+						"url": {
+							"raw": "{{MAKER_CND_URL}}/dial",
+							"host": [
+								"{{MAKER_CND_URL}}"
+							],
+							"path": [
+								"dial"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET /orders (Maker)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{MAKER_CND_URL}}/orders",
+							"host": [
+								"{{MAKER_CND_URL}}"
+							],
+							"path": [
+								"orders"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "GET / (Maker) >> MAKER_MULTI_ADR",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5145203a-6cdd-4fd1-ac8a-913d2e92c445",
+						"exec": [
+							"var json = JSON.parse(responseBody);",
+							"postman.setEnvironmentVariable(\"MAKER_MULTI_ADR\", JSON.stringify(json.listen_addresses)); // save as JSON, because it will be used in next request body"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{MAKER_CND_URL}}",
+					"host": [
+						"{{MAKER_CND_URL}}"
+					]
+				},
+				"description": "GET /\nSet MAKER_MULTI_ADR variable (see script in Tests tab)"
+			},
+			"response": []
+		},
+		{
+			"name": "POST /dial (Taker2Maker)",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"addresses\": {{MAKER_MULTI_ADR}}\n}"
+				},
+				"url": {
+					"raw": "{{TAKER_CND_URL}}/dial",
+					"host": [
+						"{{TAKER_CND_URL}}"
+					],
+					"path": [
+						"dial"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "POST /orders (Maker)",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"position\": \"sell\",\n    \"bitcoin_amount\": \"19\",\n    \"bitcoin_ledger\": \"regtest\",\n    \"bitcoin_absolute_expiry\": 400,\n    \"ethereum_amount\": \"89000\",\n    \"token_contract\": \"0x62d69f6867a0a084c6d313943dc22023bc263691\",\n    \"ethereum_ledger\": {\"chain_id\":1337},\n    \"ethereum_absolute_expiry\": 600,\n    \"bitcoin_identity\": \"1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX\",\n    \"ethereum_identity\": \"0x00a329c0648769a73afac7f9381e08fb43dbea72\",\n    \"maker_addr\": \"/ip4/127.0.0.1/tcp/9939\"\n}"
+				},
+				"url": {
+					"raw": "{{MAKER_CND_URL}}/orders",
+					"host": [
+						"{{MAKER_CND_URL}}"
+					],
+					"path": [
+						"orders"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "GET /orders (Taker) >> ORDER_ID",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d3f05bea-bffe-4889-90bd-43ff0b238e35",
+						"exec": [
+							"var json = JSON.parse(responseBody);",
+							"let lastOrder = json.entities[0];",
+							"let orderId = lastOrder.properties.id;",
+							"postman.setEnvironmentVariable(\"ORDER_ID\", orderId); // save as string because it will be part of the URL for posting order-take"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{TAKER_CND_URL}}/orders",
+					"host": [
+						"{{TAKER_CND_URL}}"
+					],
+					"path": [
+						"orders"
+					]
+				},
+				"description": "Set ORDER_ID variable (see script in Tests tab)"
+			},
+			"response": []
+		},
+		{
+			"name": "POST /orders/:id/take (Taker) >> SWAP_LOCATION",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"bitcoin_identity\": \"1F1tAaz5x1HUXrCNLbtMDqcw6o5GNn4xqX\",\n    \"ethereum_identity\": \"0x5617ACCC620010D9A6b27C434210f90C6F10EdF6\"\n}"
+				},
+				"url": {
+					"raw": "{{TAKER_CND_URL}}/orders/{{ORDER_ID}}/take",
+					"host": [
+						"{{TAKER_CND_URL}}"
+					],
+					"path": [
+						"orders",
+						"{{ORDER_ID}}",
+						"take"
+					]
+				},
+				"description": "Set SWAP_LOCATION variable (see script in Tests tab)"
+			},
+			"response": []
+		},
+		{
+			"name": "GET /swaps/:id (Taker)",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{TAKER_CND_URL}}{{SWAP_LOCATION}}",
+					"host": [
+						"{{TAKER_CND_URL}}{{SWAP_LOCATION}}"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/postman/CND Orderbook REST API.postman_collection.json
+++ b/postman/CND Orderbook REST API.postman_collection.json
@@ -6,79 +6,6 @@
 	},
 	"item": [
 		{
-			"name": "ARCHIVED",
-			"item": [
-				{
-					"name": "GET / (Taker)",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{TAKER_CND_URL}}",
-							"host": [
-								"{{TAKER_CND_URL}}"
-							]
-						},
-						"description": "GET /\n"
-					},
-					"response": []
-				},
-				{
-					"name": "POST /dial (Maker2Taker)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n\t\"addresses\": [\"/ip4/124.19.31.4/tcp/9939\"]\n}"
-						},
-						"url": {
-							"raw": "{{MAKER_CND_URL}}/dial",
-							"host": [
-								"{{MAKER_CND_URL}}"
-							],
-							"path": [
-								"dial"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "GET /orders (Maker)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{MAKER_CND_URL}}/orders",
-							"host": [
-								"{{MAKER_CND_URL}}"
-							],
-							"path": [
-								"orders"
-							]
-						}
-					},
-					"response": []
-				}
-			],
-			"protocolProfileBehavior": {}
-		},
-		{
 			"name": "GET / (Maker) >> MAKER_MULTI_ADR",
 			"event": [
 				{
@@ -204,6 +131,19 @@
 		},
 		{
 			"name": "POST /orders/:id/take (Taker) >> SWAP_LOCATION",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "6aadef6a-3b31-4a23-b8e4-b55eb0f37ffa",
+						"exec": [
+							"var swapLocation = pm.response.headers.get(\"location\");",
+							"postman.setEnvironmentVariable(\"SWAP_LOCATION\", swapLocation); // save as string because it will be part of the URL for posting order-take"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
 			"request": {
 				"method": "POST",
 				"header": [

--- a/postman/COMIT - Taker UI App.postman_environment.json
+++ b/postman/COMIT - Taker UI App.postman_environment.json
@@ -1,0 +1,34 @@
+{
+	"id": "38faccb6-8011-427a-b459-bf946b2efcff",
+	"name": "COMIT - Taker UI App",
+	"values": [
+		{
+			"key": "TAKER_CND_URL",
+			"value": "http://127.0.0.1:55110",
+			"enabled": true
+		},
+		{
+			"key": "MAKER_CND_URL",
+			"value": "http://127.0.0.1:55103",
+			"enabled": true
+		},
+		{
+			"key": "MAKER_MULTI_ADR",
+			"value": "[\"/ip4/127.0.0.1/tcp/9939\",\"/ip4/172.19.0.4/tcp/9939\"]",
+			"enabled": true
+		},
+		{
+			"key": "ORDER_ID",
+			"value": "68cc7f5e-66ec-4748-a894-3fc9f8121257",
+			"enabled": true
+		},
+		{
+			"key": "SWAP_LOCATION",
+			"value": "/swaps/e4b6c277-d326-4d57-9413-4ac7d2f738e2",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-07-29T04:43:17.238Z",
+	"_postman_exported_using": "Postman/7.27.0"
+}

--- a/postman/COMIT - Taker UI App.postman_environment.json
+++ b/postman/COMIT - Taker UI App.postman_environment.json
@@ -4,22 +4,22 @@
 	"values": [
 		{
 			"key": "TAKER_CND_URL",
-			"value": "http://127.0.0.1:55110",
+			"value": "http://127.0.0.1:8000",
 			"enabled": true
 		},
 		{
 			"key": "MAKER_CND_URL",
-			"value": "http://127.0.0.1:55103",
+			"value": "http://127.0.0.1:7000",
 			"enabled": true
 		},
 		{
 			"key": "MAKER_MULTI_ADR",
-			"value": "[\"/ip4/127.0.0.1/tcp/9939\",\"/ip4/172.19.0.4/tcp/9939\"]",
+			"value": "[\"/ip4/127.0.0.1/tcp/9940\"]",
 			"enabled": true
 		},
 		{
 			"key": "ORDER_ID",
-			"value": "68cc7f5e-66ec-4748-a894-3fc9f8121257",
+			"value": "fb079fe6-a0fe-494c-a825-0bab85d3872d",
 			"enabled": true
 		},
 		{
@@ -29,6 +29,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2020-07-29T04:43:17.238Z",
-	"_postman_exported_using": "Postman/7.27.0"
+	"_postman_exported_at": "2020-08-05T03:54:47.147Z",
+	"_postman_exported_using": "Postman/7.29.1"
 }


### PR DESCRIPTION
Nice to have to be able to create orders as maker and see how cnd's order API works.
Note that the collection is optimized to be able to just click through - automatically set from responses are: maker-addresses (for dialing from taker to maker) order-id and swap-id.
The only thing that has to be configured is the ports when starting a new environment. 

@bonomat I changed the dial to be from taker to maker and it works :)

Once taker and maker are working properly together and cnd is stably released we can consider removing them again. 