### PR TITLE
Refresh balance every 10 seconds using custom hooks

### DIFF
--- a/app/components/BalanceHorizontal.tsx
+++ b/app/components/BalanceHorizontal.tsx
@@ -1,78 +1,20 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Flex, StatGroup } from '@chakra-ui/core';
 import CurrencyAmount from './CurrencyAmount';
-import {
-  amountToUnitString,
-  btcIntoCurVal,
-  daiIntoCurVal,
-  ethIntoCurVal,
-  ZERO_BTC,
-  ZERO_DAI,
-  ZERO_ETH
-} from '../utils/currency';
-import { useLedgerEthereumWallet } from '../hooks/useLedgerEthereumWallet';
-import { useLedgerBitcoinWallet } from '../hooks/useLedgerBitcoinWallet';
+import { amountToUnitString } from '../utils/currency';
 import { intoOrders } from '../utils/order';
 import { intoBook } from '../utils/book';
 import { useCnd } from '../hooks/useCnd';
 import useSWR from 'swr/esm/use-swr';
+import useEtherBalance from '../hooks/useEtherBalance';
+import useDaiBalance from '../hooks/useDaiBalance';
+import useBitcoinBalance from '../hooks/useBitcoinBalance';
 
 export default function BalanceHorizontal() {
-  // TODO: Duplicate of Dashboard setup, refactor
-  const ethWallet = useLedgerEthereumWallet();
-  const btcWallet = useLedgerBitcoinWallet();
   const cnd = useCnd();
-
-  const [ethBalanceAsCurrencyValue, setEthBalanceAsCurrencyValue] = useState(
-    ZERO_ETH
-  );
-  const [daiBalanceAsCurrencyValue, setDaiBalanceAsCurrencyValue] = useState(
-    ZERO_DAI
-  );
-  const [btcBalanceAsCurrencyValue, setBtcBalanceAsCurrencyValue] = useState(
-    ZERO_BTC
-  );
-
-  useEffect(() => {
-    async function loadEthBalance() {
-      try {
-        const eth = await ethWallet.getEtherBalance();
-        const ethCurrencyValue = ethIntoCurVal(eth);
-        setEthBalanceAsCurrencyValue(ethCurrencyValue);
-      } catch (e) {
-        console.error(e);
-        console.warn('Falling back to ETH balance 0.');
-      }
-
-      try {
-        const dai = await ethWallet.getErc20Balance(
-          await cnd.daiContractAddress()
-        );
-        const daiCurrencyValue = daiIntoCurVal(dai);
-        setDaiBalanceAsCurrencyValue(daiCurrencyValue);
-      } catch (e) {
-        console.error(e);
-        console.warn('Falling back to DAI balance 0.');
-      }
-    }
-
-    if (ethWallet) loadEthBalance();
-  }, [ethWallet]);
-
-  useEffect(() => {
-    async function loadBtcBalance() {
-      try {
-        const sats = await btcWallet.getBalance();
-        const btcCurrencyValue = btcIntoCurVal(sats);
-        setBtcBalanceAsCurrencyValue(btcCurrencyValue);
-      } catch (e) {
-        console.error(e);
-        console.warn('Falling back to BTC balance 0.');
-      }
-    }
-
-    if (btcWallet) loadBtcBalance();
-  }, [btcWallet]);
+  const ethBalanceAsCurrencyValue = useEtherBalance();
+  const daiBalanceAsCurrencyValue = useDaiBalance();
+  const btcBalanceAsCurrencyValue = useBitcoinBalance();
 
   const ordersEndpoint = '/orders';
   const { data: orders } = useSWR(

--- a/app/components/CurrencyAmount.tsx
+++ b/app/components/CurrencyAmount.tsx
@@ -168,7 +168,7 @@ export default function CurrencyAmount({
               whiteSpace="nowrap"
             >
               {displayAmount}
-              {showCurrencyText ? ` ${currency}` : <></>}
+              {showCurrencyText && ` ${currency}`}
             </StatNumber>
           )}
         </Flex>

--- a/app/components/CurrencyAmount.tsx
+++ b/app/components/CurrencyAmount.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Flex,
   Image,
+  Spinner,
   Stat,
   StatHelpText,
   StatLabel,
@@ -155,18 +156,21 @@ export default function CurrencyAmount({
       >
         <Flex direction="row" alignContent="center" minWidth={displayMinWidth}>
           {noImage ? <></> : currencyIcon(currency, iconHeight)}
-          {/* @ts-ignore */}
-          <StatNumber
-            color={displayNumberColor}
-            fontSize={amountFontSize}
-            overflow="hidden"
-            // @ts-ignore
-            textOverflow="ellipsis"
-            whiteSpace="nowrap"
-          >
-            {displayAmount}
-            {showCurrencyText ? ` ${currency}` : <></>}
-          </StatNumber>
+          {displayAmount === '0' || displayAmount.startsWith('-') ? (
+            <Spinner size="sm" />
+          ) : (
+            <StatNumber
+              color={displayNumberColor}
+              fontSize={amountFontSize}
+              overflow="hidden"
+              // @ts-ignore
+              textOverflow="ellipsis"
+              whiteSpace="nowrap"
+            >
+              {displayAmount}
+              {showCurrencyText ? ` ${currency}` : <></>}
+            </StatNumber>
+          )}
         </Flex>
       </Tooltip>
     </Flex>

--- a/app/components/MyOrderList.tsx
+++ b/app/components/MyOrderList.tsx
@@ -62,9 +62,9 @@ export default function MyOrderList({
                   await actionToHttpRequest(cancelAction)
                 );
                 await mutate('/orders');
-                await mutate('/bitcoin/balance');
-                await mutate('/ether/balance');
-                await mutate('/dai/balance');
+                await mutate('/balance/btc');
+                await mutate('/balance/eth');
+                await mutate('/balance/dai');
               }}
               variantColor={cancelButtonColor}
             />

--- a/app/components/MyOrderList.tsx
+++ b/app/components/MyOrderList.tsx
@@ -62,6 +62,9 @@ export default function MyOrderList({
                   await actionToHttpRequest(cancelAction)
                 );
                 await mutate('/orders');
+                await mutate('/bitcoin/balance');
+                await mutate('/ether/balance');
+                await mutate('/dai/balance');
               }}
               variantColor={cancelButtonColor}
             />

--- a/app/components/OrderCreator.tsx
+++ b/app/components/OrderCreator.tsx
@@ -41,6 +41,7 @@ import { useLedgerEthereumWallet } from '../hooks/useLedgerEthereumWallet';
 import { useLedgerBitcoinWallet } from '../hooks/useLedgerBitcoinWallet';
 import { useCnd } from '../hooks/useCnd';
 import { useConfig } from '../config';
+import { mutate } from 'swr';
 
 interface OrderCreatorProperties {
   highestPriceBuyOrder: MarketOrder;
@@ -343,12 +344,12 @@ function Form({ initialState, label, variantColor }: FormProperties) {
 
         const priceBigInt = BigNumber.from(daiIntoCurVal(state.price).value);
 
-        const orderHref = await postBtcDaiOrder(
-          state.position,
-          quantityBigInt,
-          priceBigInt
-        );
-        console.log(orderHref);
+        await postBtcDaiOrder(state.position, quantityBigInt, priceBigInt);
+
+        await mutate('/orders');
+        await mutate('/bitcoin/balance');
+        await mutate('/ether/balance');
+        await mutate('/dai/balance');
       }}
     >
       <fieldset disabled={state.ethErrorMessage != ''}>

--- a/app/components/OrderCreator.tsx
+++ b/app/components/OrderCreator.tsx
@@ -347,9 +347,9 @@ function Form({ initialState, label, variantColor }: FormProperties) {
         await postBtcDaiOrder(state.position, quantityBigInt, priceBigInt);
 
         await mutate('/orders');
-        await mutate('/bitcoin/balance');
-        await mutate('/ether/balance');
-        await mutate('/dai/balance');
+        await mutate('/balance/btc');
+        await mutate('/balance/eth');
+        await mutate('/balance/dai');
       }}
     >
       <fieldset disabled={state.ethErrorMessage != ''}>

--- a/app/hooks/useBitcoinBalance.tsx
+++ b/app/hooks/useBitcoinBalance.tsx
@@ -1,0 +1,19 @@
+import { useLedgerBitcoinWallet } from './useLedgerBitcoinWallet';
+import useSWR from 'swr/esm/use-swr';
+import { btcIntoCurVal, ZERO_BTC } from '../utils/currency';
+
+export default function useBitcoinBalance() {
+  const btcWallet = useLedgerBitcoinWallet();
+  const { data: balance } = useSWR(
+    '/bitcoin/balance',
+    () => btcWallet.getBalance().then(b => btcIntoCurVal(b)),
+    {
+      refreshInterval: 10000,
+      errorRetryInterval: 500,
+      errorRetryCount: 10,
+      initialData: ZERO_BTC
+    }
+  );
+
+  return balance;
+}

--- a/app/hooks/useBitcoinBalance.tsx
+++ b/app/hooks/useBitcoinBalance.tsx
@@ -1,19 +1,20 @@
 import { useLedgerBitcoinWallet } from './useLedgerBitcoinWallet';
 import useSWR from 'swr/esm/use-swr';
-import { btcIntoCurVal, ZERO_BTC } from '../utils/currency';
+import { btcIntoCurVal } from '../utils/currency';
+import { BigNumber } from 'ethers';
 
 export default function useBitcoinBalance() {
   const btcWallet = useLedgerBitcoinWallet();
   const { data: balance } = useSWR(
-    '/bitcoin/balance',
-    () => btcWallet.getBalance().then(b => btcIntoCurVal(b)),
+    '/balance/btc',
+    () => btcWallet.getBalance(),
     {
       refreshInterval: 10000,
       errorRetryInterval: 500,
       errorRetryCount: 10,
-      initialData: ZERO_BTC
+      initialData: BigNumber.from(0)
     }
   );
 
-  return balance;
+  return btcIntoCurVal(balance);
 }

--- a/app/hooks/useDaiBalance.tsx
+++ b/app/hooks/useDaiBalance.tsx
@@ -1,8 +1,9 @@
 import useSWR from 'swr/esm/use-swr';
-import { daiIntoCurVal, ZERO_DAI } from '../utils/currency';
+import { daiIntoCurVal } from '../utils/currency';
 import { useLedgerEthereumWallet } from './useLedgerEthereumWallet';
 import { useCnd } from './useCnd';
 import { useEffect, useState } from 'react';
+import { BigNumber } from 'ethers';
 
 export default function useDaiBalance() {
   const cnd = useCnd();
@@ -23,16 +24,15 @@ export default function useDaiBalance() {
 
   const ethWallet = useLedgerEthereumWallet();
   const { data: balance } = useSWR(
-    daiContractAddress ? '/dai/balance' : null,
-    () =>
-      ethWallet.getErc20Balance(daiContractAddress).then(b => daiIntoCurVal(b)),
+    daiContractAddress ? '/balance/dai' : null,
+    () => ethWallet.getErc20Balance(daiContractAddress),
     {
       refreshInterval: 10000,
       errorRetryInterval: 500,
       errorRetryCount: 10,
-      initialData: ZERO_DAI
+      initialData: BigNumber.from(0)
     }
   );
 
-  return balance;
+  return daiIntoCurVal(balance);
 }

--- a/app/hooks/useDaiBalance.tsx
+++ b/app/hooks/useDaiBalance.tsx
@@ -1,0 +1,38 @@
+import useSWR from 'swr/esm/use-swr';
+import { daiIntoCurVal, ZERO_DAI } from '../utils/currency';
+import { useLedgerEthereumWallet } from './useLedgerEthereumWallet';
+import { useCnd } from './useCnd';
+import { useEffect, useState } from 'react';
+
+export default function useDaiBalance() {
+  const cnd = useCnd();
+  const [daiContractAddress, setDaiContractAddress] = useState(null);
+
+  useEffect(() => {
+    async function loadDaiContractAddress() {
+      try {
+        const contract = await cnd.daiContractAddress();
+        setDaiContractAddress(contract);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    if (!daiContractAddress) loadDaiContractAddress();
+  }, [cnd]);
+
+  const ethWallet = useLedgerEthereumWallet();
+  const { data: balance } = useSWR(
+    daiContractAddress ? '/dai/balance' : null,
+    () =>
+      ethWallet.getErc20Balance(daiContractAddress).then(b => daiIntoCurVal(b)),
+    {
+      refreshInterval: 10000,
+      errorRetryInterval: 500,
+      errorRetryCount: 10,
+      initialData: ZERO_DAI
+    }
+  );
+
+  return balance;
+}

--- a/app/hooks/useEtherBalance.tsx
+++ b/app/hooks/useEtherBalance.tsx
@@ -1,19 +1,20 @@
 import useSWR from 'swr/esm/use-swr';
-import { ethIntoCurVal, ZERO_ETH } from '../utils/currency';
+import { ethIntoCurVal } from '../utils/currency';
 import { useLedgerEthereumWallet } from './useLedgerEthereumWallet';
+import { BigNumber } from 'ethers';
 
 export default function useEtherBalance() {
   const ethWallet = useLedgerEthereumWallet();
   const { data: balance } = useSWR(
-    '/ether/balance',
-    () => ethWallet.getEtherBalance().then(b => ethIntoCurVal(b)),
+    '/balance/eth',
+    () => ethWallet.getEtherBalance(),
     {
       refreshInterval: 10000,
       errorRetryInterval: 500,
       errorRetryCount: 10,
-      initialData: ZERO_ETH
+      initialData: BigNumber.from(0)
     }
   );
 
-  return balance;
+  return ethIntoCurVal(balance);
 }

--- a/app/hooks/useEtherBalance.tsx
+++ b/app/hooks/useEtherBalance.tsx
@@ -1,0 +1,19 @@
+import useSWR from 'swr/esm/use-swr';
+import { ethIntoCurVal, ZERO_ETH } from '../utils/currency';
+import { useLedgerEthereumWallet } from './useLedgerEthereumWallet';
+
+export default function useEtherBalance() {
+  const ethWallet = useLedgerEthereumWallet();
+  const { data: balance } = useSWR(
+    '/ether/balance',
+    () => ethWallet.getEtherBalance().then(b => ethIntoCurVal(b)),
+    {
+      refreshInterval: 10000,
+      errorRetryInterval: 500,
+      errorRetryCount: 10,
+      initialData: ZERO_ETH
+    }
+  );
+
+  return balance;
+}

--- a/app/pages/DashboardPage.tsx
+++ b/app/pages/DashboardPage.tsx
@@ -1,82 +1,25 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Box, Flex, Text } from '@chakra-ui/core';
 import SwapList from '../components/SwapList';
 import OrderCreator from '../components/OrderCreator';
 import AvailableBalance from '../components/AvailableBalance';
 import MarketOrderList from '../components/MarketOrderList';
 import MyOrderList from '../components/MyOrderList';
-import { useLedgerEthereumWallet } from '../hooks/useLedgerEthereumWallet';
-import { useLedgerBitcoinWallet } from '../hooks/useLedgerBitcoinWallet';
-import {
-  btcIntoCurVal,
-  daiIntoCurVal,
-  ethIntoCurVal,
-  ZERO_BTC,
-  ZERO_DAI,
-  ZERO_ETH
-} from '../utils/currency';
 import { intoBook } from '../utils/book';
 import { useCnd } from '../hooks/useCnd';
 import useSWR from 'swr/esm/use-swr';
 import { intoOrders } from '../utils/order';
 import { intoMarket } from '../utils/market';
 import BidAndAsk from '../components/BidAndAsk';
+import useBitcoinBalance from '../hooks/useBitcoinBalance';
+import useDaiBalance from '../hooks/useDaiBalance';
+import useEtherBalance from '../hooks/useEtherBalance';
 
 export default function DashboardPage() {
-  const ethWallet = useLedgerEthereumWallet();
-  const btcWallet = useLedgerBitcoinWallet();
   const cnd = useCnd();
-
-  const [ethBalanceAsCurrencyValue, setEthBalanceAsCurrencyValue] = useState(
-    ZERO_ETH
-  );
-  const [daiBalanceAsCurrencyValue, setDaiBalanceAsCurrencyValue] = useState(
-    ZERO_DAI
-  );
-  const [btcBalanceAsCurrencyValue, setBtcBalanceAsCurrencyValue] = useState(
-    ZERO_BTC
-  );
-
-  useEffect(() => {
-    async function loadEthBalance() {
-      try {
-        const eth = await ethWallet.getEtherBalance();
-        const ethCurrencyValue = ethIntoCurVal(eth);
-        setEthBalanceAsCurrencyValue(ethCurrencyValue);
-      } catch (e) {
-        console.error(e);
-        console.warn('Falling back to ETH balance 0.');
-      }
-
-      try {
-        const dai = await ethWallet.getErc20Balance(
-          await cnd.daiContractAddress()
-        );
-        const daiCurrencyValue = daiIntoCurVal(dai);
-        setDaiBalanceAsCurrencyValue(daiCurrencyValue);
-      } catch (e) {
-        console.error(e);
-        console.warn('Falling back to DAI balance 0.');
-      }
-    }
-
-    if (ethWallet) loadEthBalance();
-  }, [ethWallet]);
-
-  useEffect(() => {
-    async function loadBtcBalance() {
-      try {
-        const sats = await btcWallet.getBalance();
-        const btcCurrencyValue = btcIntoCurVal(sats);
-        setBtcBalanceAsCurrencyValue(btcCurrencyValue);
-      } catch (e) {
-        console.error(e);
-        console.warn('Falling back to BTC balance 0.');
-      }
-    }
-
-    if (btcWallet) loadBtcBalance();
-  }, [btcWallet]);
+  const ethBalanceAsCurrencyValue = useEtherBalance();
+  const daiBalanceAsCurrencyValue = useDaiBalance();
+  const btcBalanceAsCurrencyValue = useBitcoinBalance();
 
   const { data: orders } = useSWR(
     '/orders',


### PR DESCRIPTION
Mutate after an order is created or cancelled.
Otherwise periodic refresh after 10secs or every 500ms upon error (to bridge the initial loading).
To avoid confusion with balances being slower in availability than orders (which results in the display of negative available balance...) I added a spinner in case the balance is `0` or starts with `-` (I felt a simple check on the string should do...).