### PR TITLE
Prevent the orderlist from breaking the design

### DIFF
--- a/app/components/CurrencyAmount.tsx
+++ b/app/components/CurrencyAmount.tsx
@@ -141,7 +141,7 @@ export default function CurrencyAmount({
     }
   }
 
-  let displayMinWidth = '100px';
+  let displayMinWidth = '80px';
   if (minWidth) {
     displayMinWidth = minWidth;
   }

--- a/app/components/MyOrderList.tsx
+++ b/app/components/MyOrderList.tsx
@@ -22,7 +22,6 @@ export default function MyOrderList({
 
   const rows = [];
   const currencyValueWidth = '25%';
-  const openAmountWidth = '25%';
   const cancelButtonWidth = '30px';
 
   const currencyValuePadding = '0.3rem';
@@ -98,7 +97,7 @@ export default function MyOrderList({
               noImage
             />
           </Box>
-          <Box width={openAmountWidth}>
+          <Box width={currencyValueWidth}>
             <CurrencyAmount
               currencyValue={order.state.open}
               amountFontSize="sm"
@@ -147,11 +146,7 @@ export default function MyOrderList({
           {currencyValHeader('Price', 'DAI')}
           {currencyValHeader('Quantity', 'BTC')}
           {currencyValHeader('Quote', 'DAI')}
-          <Box h="25px" paddingTop="0.1rem" width={openAmountWidth}>
-            <Text fontSize="sd" fontWeight="bold">
-              Open
-            </Text>
-          </Box>
+          {currencyValHeader('Open', 'BTC')}
         </Flex>
         <Flex
           direction="column"

--- a/app/components/SwapRow.tsx
+++ b/app/components/SwapRow.tsx
@@ -288,9 +288,17 @@ export default function SwapRow({ href }: SwapRowProps) {
 
   const sendAmountDisplay =
     sendCurrency === Currency.BTC ? (
-      <CurrencyAmount currencyValue={sendAmount} topText={sendAmountLabel} />
+      <CurrencyAmount
+        currencyValue={sendAmount}
+        topText={sendAmountLabel}
+        minWidth="100px"
+      />
     ) : (
-      <CurrencyAmount currencyValue={sendAmount} topText={sendAmountLabel} />
+      <CurrencyAmount
+        currencyValue={sendAmount}
+        topText={sendAmountLabel}
+        minWidth="100px"
+      />
     );
 
   const receiveAmountDisplay =
@@ -298,11 +306,13 @@ export default function SwapRow({ href }: SwapRowProps) {
       <CurrencyAmount
         currencyValue={receiveAmount}
         topText={receiveAmountLabel}
+        minWidth="100px"
       />
     ) : (
       <CurrencyAmount
         currencyValue={receiveAmount}
         topText={receiveAmountLabel}
+        minWidth="100px"
       />
     );
 


### PR DESCRIPTION
This is a minor fix.

Setting the min width of the CurrencyAmount was the easiest way to achieve this.
Can be tackled in a better way once we touch the refactoring of CurrencyAmount / CurrencyValue.