### PR TITLE
Do not publish draft release upon dependabot packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,17 +65,17 @@ jobs:
         run: |
           yarn package-ci
       - uses: actions/upload-artifact@v2
-        if: matrix.os == 'macOS-latest'
+        if: matrix.os == 'macOS-latest' && github.actor != 'dependabot'
         with:
           name: ${{ matrix.os }}-app
           path: release/*.dmg
       - uses: actions/upload-artifact@v2
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest' && github.actor != 'dependabot'
         with:
           name: ${{ matrix.os }}-app
           path: release/*.exe
       - uses: actions/upload-artifact@v2
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && github.actor != 'dependabot'
         with:
           name: ${{ matrix.os }}-app
           path: release/*.AppImage


### PR DESCRIPTION
Due to an upload bug - https://github.com/actions/upload-artifact/issues/116 - we frequently have to re-trigger the build.
It is unnecessary to publish a draft after a dependabot related build, thus exclude those PRs by dependabot user.