### PR TITLE
Auto attach executables to release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,20 +45,10 @@ jobs:
           yarn lint
           yarn tsc
 
-      # - name: yarn test
-      #   run: |
-      #     yarn build
-      #     yarn test
-
-      # - name: Run E2E test
-      #   uses: GabrielBB/xvfb-action@v1.2
-      #   with:
-      #     working-directory: ./ #optional
-      #     run: |
-      #       yarn build-e2e
-      #       yarn test-e2e
-
       - name: yarn package
+        # Token needed for cleanup (removing token triggered error in windows workflow)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn package-ci
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,8 +38,7 @@ jobs:
           key: ${{ matrix.os }}-app-node-modules-${{ hashFiles('app/yarn.lock') }}
 
       - name: yarn install
-        run: |
-          yarn install
+        run: yarn install
 
       - name: yarn lint
         run: |
@@ -60,10 +59,8 @@ jobs:
       #       yarn test-e2e
 
       - name: yarn package
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          yarn package-ci
+        run: yarn package-ci
+
       - uses: actions/upload-artifact@v2
         if: matrix.os == 'macOS-latest' && github.actor != 'dependabot'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
         run: yarn install
 
       - name: yarn package
+        # Token needed for cleanup (removing token triggered error in windows workflow)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn package-ci
 
       - name: Upload mac release binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./release/Ambrosia-${{github.event.release.tag_name}}.dmg
           asset_name: Ambrosia-${{github.event.release.tag_name}}.dmg
-          asset_content_type: application/dmg
+          asset_content_type: application/octet-stream
 
       - name: Upload linux release binary
         if: matrix.os == 'ubuntu-latest'
@@ -49,7 +49,7 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./release/Ambrosia-${{github.event.release.tag_name}}.AppImage
           asset_name: Ambrosia-${{github.event.release.tag_name}}.AppImage
-          asset_content_type: application/AppImage
+          asset_content_type: application/octet-stream
 
       - name: Upload windows release binary
         if: matrix.os == 'windows-latest'
@@ -60,4 +60,4 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./release/Ambrosia-${{github.event.release.tag_name}}.exe
           asset_name: Ambrosia-${{github.event.release.tag_name}}.exe
-          asset_content_type: application/exe
+          asset_content_type: application/vnd.microsoft.portable-executable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: 'Release Ambrosia'
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: Release ambrosia
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+          token: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 13
+
+      - name: yarn install
+        run: yarn install
+
+      - name: yarn package
+        run: yarn package-ci
+
+      - name: Upload mac release binary
+        if: matrix.os == 'macOS-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release/Ambrosia-${{github.event.release.tag_name}}.dmg
+          asset_name: Ambrosia-${{github.event.release.tag_name}}.dmg
+          asset_content_type: application/dmg
+
+      - name: Upload linux release binary
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release/Ambrosia-${{github.event.release.tag_name}}.AppImage
+          asset_name: Ambrosia-${{github.event.release.tag_name}}.AppImage
+          asset_content_type: application/AppImage
+
+      - name: Upload windows release binary
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./release/Ambrosia-${{github.event.release.tag_name}}.exe
+          asset_name: Ambrosia-${{github.event.release.tag_name}}.exe
+          asset_content_type: application/exe


### PR DESCRIPTION
Release manually triggered in Github UI.
Executables are built and uploaded to the release by the workflow.